### PR TITLE
fix: limit channels to 16

### DIFF
--- a/src/audio_connection.c
+++ b/src/audio_connection.c
@@ -86,7 +86,7 @@ static AudioDevice *add_device_and_conns(Session *session, int index, int iscapt
     int *conn_index = iscapture ? &session->audio_io.num_record_conns : &session->audio_io.num_playback_conns;
 
     int channel_i = 0;
-    while (channel_i < dev->spec.channels) {
+    while (channel_i < dev->spec.channels && channel_i < 16) {
 	AudioConn *conn = calloc(sizeof(AudioConn), 1);
 	if (dev->spec.channels - channel_i >= 2) {
 	    conn->channel_cfg.L_src = channel_i;

--- a/src/audio_connection.c
+++ b/src/audio_connection.c
@@ -86,7 +86,7 @@ static AudioDevice *add_device_and_conns(Session *session, int index, int iscapt
     int *conn_index = iscapture ? &session->audio_io.num_record_conns : &session->audio_io.num_playback_conns;
 
     int channel_i = 0;
-    while (channel_i < dev->spec.channels && channel_i < 16) {
+    while (channel_i < dev->spec.channels && channel_i < MAX_INPUT_CHANNELS - 1) {
 	AudioConn *conn = calloc(sizeof(AudioConn), 1);
 	if (dev->spec.channels - channel_i >= 2) {
 	    conn->channel_cfg.L_src = channel_i;


### PR DESCRIPTION
I have several virtual audio devices with many (many) channels, which was causing jackdaw to segfault on startup by trying to assign channels past the memory allocated for them. this patch prevents that segfault by limiting to the observed maximum of 16.

this might not be the optimal fix.